### PR TITLE
feat: Add AJAX product category filtering and implementation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,98 @@
+# WooCommerce Product Category Filter Implementation Guide
+
+This guide provides step-by-step instructions on how to implement the AJAX product category filter functionality on your WordPress site using cPanel.
+
+## Files Overview
+
+You should have the following new/modified files:
+
+1.  **`page-boutique-ortoc.php`**: The modified PHP template for your shop page. This file now includes the HTML for the filter buttons and the necessary CSS styling.
+2.  **`ortoc-category-filter.js`**: The JavaScript file that handles the user interaction (clicking filter buttons) and makes AJAX requests to filter products without reloading the page.
+3.  **`ortoc-ajax-functions.php`**: A PHP file containing the necessary WordPress hooks and functions to:
+    *   Properly load (enqueue) the `ortoc-category-filter.js` script.
+    *   Provide the JavaScript with necessary data (like the AJAX URL and a security nonce).
+    *   Handle the AJAX requests sent by the JavaScript to fetch and return filtered product lists.
+
+## Implementation Steps via cPanel
+
+**Prerequisite:** Ensure you know the name of your currently active WordPress theme. You can find this in your WordPress admin area under "Appearance" > "Themes".
+
+### Step 1: Access Your Theme Files in cPanel
+
+1.  Log in to your **cPanel**.
+2.  Navigate to the **File Manager**.
+3.  In the File Manager, go to your WordPress installation directory. This is usually `public_html` or a subdirectory if WordPress is installed there.
+4.  Navigate to your active theme's directory: `wp-content/themes/your-active-theme-name/` (replace `your-active-theme-name` with the actual folder name of your theme).
+
+### Step 2: Upload and Update Files
+
+1.  **`page-boutique-ortoc.php`**
+    *   **If `page-boutique-ortoc.php` already exists in your theme's root directory (`wp-content/themes/your-active-theme-name/`):**
+        *   Upload the new version of `page-boutique-ortoc.php` (that I provided) to this directory, overwriting the existing file.
+    *   **If your shop page template is located elsewhere (e.g., a subfolder like `templates/` or `woocommerce/` within your theme):**
+        *   You'll need to identify the correct file and path for your specific shop page. The filtering buttons and CSS were added directly to `page-boutique-ortoc.php`. If your theme uses a different file for the main shop/product listing, the changes (PHP for buttons, CSS block) would need to be integrated into that specific file instead. **For now, assume it's in the theme root as `page-boutique-ortoc.php`.**
+    *   **Action:** Upload `page-boutique-ortoc.php` to `wp-content/themes/your-active-theme-name/`.
+
+2.  **`ortoc-category-filter.js`**
+    *   **Action:** Upload the `ortoc-category-filter.js` file to your theme's root directory: `wp-content/themes/your-active-theme-name/`.
+    *   *(Note: The PHP code in `ortoc-ajax-functions.php` assumes this location. If you place it in a subdirectory, like `js/`, you'll need to modify the path in `ortoc-ajax-functions.php` as commented in that file).*
+
+3.  **`ortoc-ajax-functions.php` and `functions.php`**
+    *   This is the most critical part for making the AJAX functionality work.
+    *   **Action A (Upload `ortoc-ajax-functions.php`):** Upload the `ortoc-ajax-functions.php` file to your theme's root directory: `wp-content/themes/your-active-theme-name/`.
+    *   **Action B (Edit `functions.php`):**
+        1.  In cPanel's File Manager, find your theme's `functions.php` file. This is located at `wp-content/themes/your-active-theme-name/functions.php`.
+        2.  **Right-click** on `functions.php` and select **"Edit"** or **"Code Edit"**. (It's wise to make a backup of this file before editing, just in case).
+        3.  Scroll to the very end of the `functions.php` file.
+        4.  Add the following line of PHP code just before any closing `?>` tag (if one exists). If there's no closing `?>` tag, add it at the very end of the file:
+            ```php
+            require_once( get_template_directory() . '/ortoc-ajax-functions.php' );
+            ```
+        5.  Save the changes to `functions.php`.
+
+    *   **Alternative for `functions.php` (Less Recommended for Organization):** Instead of Actions A and B above, you could copy the *entire content* of `ortoc-ajax-functions.php` and paste it directly into the end of your theme's `functions.php` file. However, using `require_once` keeps your `functions.php` cleaner.
+
+### Step 3: How WordPress Links These Files
+
+You don't need to manually link `ortoc-category-filter.js` in your HTML like a traditional script tag. WordPress handles it:
+
+*   **`functions.php` tells WordPress about `ortoc-category-filter.js`:**
+    The code you added to `functions.php` (via `ortoc-ajax-functions.php`) includes a function hooked to `wp_enqueue_scripts`. This function, `ortoc_enqueue_category_filter_script()`, tells WordPress:
+    1.  "Here is a JavaScript file: `ortoc-category-filter.js`." (WordPress then generates the correct `<script>` tag in your site's HTML).
+    2.  "When you load this script, also give it some data: the AJAX URL (`admin-ajax.php`) and a security key (nonce). Make this data available to the script via the `ortoc_filter_params` JavaScript object."
+
+*   **JavaScript uses the data from `functions.php`:**
+    Your `ortoc-category-filter.js` script then uses `ortoc_filter_params.ajax_url` to know where to send its AJAX requests and `ortoc_filter_params.nonce` to include the security key.
+
+*   **`functions.php` listens for AJAX calls from the JavaScript:**
+    The `add_action('wp_ajax_filter_products_by_category', ...)` and `add_action('wp_ajax_nopriv_filter_products_by_category', ...)` lines in `ortoc-ajax-functions.php` tell WordPress:
+    1.  "If you receive an AJAX request specifically named `filter_products_by_category` (which our JavaScript is sending), then run the PHP function `ortoc_filter_products_by_category_handler()`."
+    2.  This handler function then queries the products based on the category sent by the JavaScript, generates the HTML for those products, and sends it back to the JavaScript.
+
+*   **JavaScript updates the page:**
+    The `ortoc-category-filter.js` receives this HTML from the PHP handler and updates the product section on your page without a full reload.
+
+### Step 4: Testing and Verification
+
+1.  **Clear Caches:** After uploading and modifying files, clear all caches:
+    *   Your browser cache.
+    *   Any caching plugins you use on your WordPress site (e.g., LiteSpeed Cache, WP Rocket).
+    *   Server-side caches if applicable (less common to need manual clearing for this type of change).
+2.  Go to your shop page (`page-boutique-ortoc.php`) on your website.
+3.  Open your browser's **Developer Tools** (usually by pressing F12) and switch to the **Console** tab and the **Network** tab. This will help you see if there are any errors or if the AJAX requests are working.
+4.  Test the filter buttons as described in the "Testing and Refinement" step of our main plan.
+
+## Troubleshooting Tips
+
+*   **White Screen or Errors after editing `functions.php`?** This usually means a PHP syntax error. Restore `functions.php` from a backup or carefully check the code you added. Ensure you didn't miss a semicolon or have incorrect syntax.
+*   **Filters not appearing or not working?**
+    *   Double-check all file paths in cPanel.
+    *   Ensure you added the `require_once` line correctly to `functions.php`.
+    *   Check the browser console for JavaScript errors.
+    *   Check the Network tab to see if `admin-ajax.php` calls are being made when you click a filter. Check their status and response.
+*   **Path to `ortoc-category-filter.js`:** If you placed `ortoc-category-filter.js` in a subfolder (e.g., `your-theme/js/ortoc-category-filter.js`), you MUST update the path in `ortoc-ajax-functions.php`. Change:
+    `get_template_directory_uri() . '/ortoc-category-filter.js'`
+    to:
+    `get_template_directory_uri() . '/js/ortoc-category-filter.js'`
+
+Good luck!

--- a/ortoc-ajax-functions.php
+++ b/ortoc-ajax-functions.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Enqueue and localize the category filter script.
+ */
+function ortoc_enqueue_category_filter_script() {
+    // Enqueue the JavaScript file
+    // IMPORTANT: Adjust the path if 'ortoc-category-filter.js' is not in the theme root.
+    // If it's in a 'js' subdirectory, for example: get_template_directory_uri() . '/js/ortoc-category-filter.js'
+    wp_enqueue_script(
+        'ortoc-category-filter',
+        get_template_directory_uri() . '/ortoc-category-filter.js', // Assuming JS is in theme root
+        array('jquery'), // Add 'jquery' if your script directly uses it, though Fetch API doesn't need it.
+        null, // Version number, null for no version or filemtime for auto-versioning
+        true  // Load in footer
+    );
+
+    // Localize the script with necessary data
+    wp_localize_script(
+        'ortoc-category-filter',
+        'ortoc_filter_params', // Object name in JavaScript
+        array(
+            'ajax_url' => admin_url('admin-ajax.php'),
+            'nonce'    => wp_create_nonce('ortoc_category_filter_nonce')
+        )
+    );
+}
+add_action('wp_enqueue_scripts', 'ortoc_enqueue_category_filter_script');
+
+/**
+ * AJAX handler for filtering products by category.
+ */
+function ortoc_filter_products_by_category_handler() {
+    // Verify the nonce for security
+    check_ajax_referer('ortoc_category_filter_nonce', '_ajax_nonce');
+
+    // Sanitize the received category slug
+    $category_slug = isset($_POST['category_slug']) ? sanitize_text_field($_POST['category_slug']) : '';
+
+    $args = array(
+        'post_type'      => 'product',
+        'posts_per_page' => 8, // Match original query or make it configurable
+        'status'         => 'publish',
+    );
+
+    // If a specific category is selected (and not 'all'), add tax_query
+    if (!empty($category_slug) && $category_slug !== 'all') {
+        $args['tax_query'] = array(
+            array(
+                'taxonomy' => 'product_cat',
+                'field'    => 'slug',
+                'terms'    => $category_slug,
+            ),
+        );
+    }
+
+    $products_query = new WP_Query($args);
+
+    ob_start(); // Start output buffering
+
+    if ($products_query->have_posts()) {
+        // Set WooCommerce loop properties if needed (e.g., columns)
+        // global $woocommerce_loop;
+        // $woocommerce_loop['columns'] = 4; // Example: if you want to control columns
+
+        woocommerce_product_loop_start();
+
+        while ($products_query->have_posts()) : $products_query->the_post();
+            global $product;
+            // Ensure product object is valid before calling wc_get_template_part
+            if (is_a($product, 'WC_Product')) {
+                 wc_get_template_part('content', 'product');
+            } else {
+                // If $product is not a WC_Product instance, try to get it.
+                $product_obj = wc_get_product(get_the_ID());
+                if(is_a($product_obj, 'WC_Product')) {
+                    $GLOBALS['product'] = $product_obj; // Set it globally for the template part
+                    wc_get_template_part('content', 'product');
+                }
+            }
+        endwhile;
+
+        woocommerce_product_loop_end();
+    } else {
+        echo '<p class="woocommerce-info">' . esc_html__('No products found matching your selection.', 'your-theme-textdomain') . '</p>';
+    }
+
+    wp_reset_postdata(); // Reset post data
+
+    $html = ob_get_clean(); // Get buffered HTML
+
+    // Send JSON response
+    wp_send_json_success(array('html' => $html));
+
+    wp_die(); // This is required to terminate immediately and return a proper response
+}
+add_action('wp_ajax_filter_products_by_category', 'ortoc_filter_products_by_category_handler');
+add_action('wp_ajax_nopriv_filter_products_by_category', 'ortoc_filter_products_by_category_handler');
+
+?>

--- a/ortoc-category-filter.js
+++ b/ortoc-category-filter.js
@@ -1,0 +1,101 @@
+document.addEventListener('DOMContentLoaded', function () {
+    // Check if localization parameters are available
+    if (typeof ortoc_filter_params === 'undefined') {
+        console.error('Localization parameters (ortoc_filter_params) not found. AJAX filtering will not work.');
+        return; // Stop execution if params are missing
+    }
+
+    const ajaxUrl = ortoc_filter_params.ajax_url;
+    const nonce = ortoc_filter_params.nonce;
+    const filterButtons = document.querySelectorAll('.filter-button');
+
+    // Attempt to find the product container
+    let productsContainer = document.querySelector('.woocommerce-products-section ul.products');
+    if (!productsContainer) {
+        // Fallback selector if the primary one isn't found
+        productsContainer = document.querySelector('section.woocommerce-products-section div.container');
+    }
+    // If still not found, log an error and disable filtering, as there's nowhere to put results.
+    if (!productsContainer) {
+        console.error('Products container not found. AJAX product filtering will not be able to display results.');
+        // Optionally, disable buttons or provide user feedback here
+        return;
+    }
+
+    filterButtons.forEach(button => {
+        button.addEventListener('click', function (event) {
+            event.preventDefault();
+
+            const categorySlug = this.dataset.category;
+
+            // Update active button state
+            filterButtons.forEach(btn => btn.classList.remove('active'));
+            this.classList.add('active');
+
+            // Add loading state
+            if (productsContainer) {
+                productsContainer.classList.add('loading');
+            }
+
+            // Prepare data for AJAX request
+            const formData = new FormData();
+            formData.append('action', 'filter_products_by_category');
+            formData.append('category_slug', categorySlug);
+            formData.append('_ajax_nonce', nonce);
+
+            // Perform AJAX request using Fetch API
+            fetch(ajaxUrl, {
+                method: 'POST',
+                body: formData,
+            })
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('Network response was not ok: ' + response.statusText);
+                }
+                return response.json(); // Parse JSON response from WordPress
+            })
+            .then(data => {
+                if (data.success && data.data && typeof data.data.html !== 'undefined') {
+                    if (productsContainer) {
+                        productsContainer.innerHTML = data.data.html;
+                    } else {
+                        // This case should ideally be prevented by the initial check,
+                        // but as a safeguard:
+                        console.error('Products container not found when trying to display results.');
+                    }
+                } else {
+                    console.error('Error processing AJAX response or no HTML received:', data);
+                    // Optionally display a user-friendly error message in the productsContainer
+                    if (productsContainer) {
+                        productsContainer.innerHTML = '<p class="woocommerce-error">Error loading products. Please try again.</p>';
+                    }
+                }
+            })
+            .catch(error => {
+                console.error('AJAX Request Failed:', error);
+                if (productsContainer) {
+                    // Display a user-friendly error message
+                    productsContainer.innerHTML = '<p class="woocommerce-error">Failed to load products. Please check your connection and try again.</p>';
+                }
+            })
+            .finally(() => {
+                // Remove loading state
+                if (productsContainer) {
+                    productsContainer.classList.remove('loading');
+                }
+            });
+        });
+    });
+
+    // Optional: Add a simple CSS rule for the loading class via JavaScript
+    // This is just for demonstration; ideally, this would be in your theme's CSS file.
+    const style = document.createElement('style');
+    style.textContent = `
+        .woocommerce-products-section ul.products.loading,
+        section.woocommerce-products-section div.container.loading {
+            opacity: 0.5;
+            transition: opacity 0.3s ease-in-out;
+        }
+    `;
+    document.head.appendChild(style);
+});

--- a/page-boutique-ortoc.php
+++ b/page-boutique-ortoc.php
@@ -513,7 +513,47 @@ get_header();
   }
 }
 
+/* Category Filter Styles */
+.category-filters-container {
+    margin-bottom: 30px; /* Space between filters and product grid */
+    padding: 0 20px; /* Align with section padding */
+}
 
+.category-filters {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 10px; /* Spacing between buttons */
+    margin-bottom: 20px; /* Space below the row of buttons */
+}
+
+.filter-button {
+    padding: 10px 20px;
+    margin: 5px;
+    border: 1px solid var(--primary-color, #0C4178); /* Use CSS variable with fallback */
+    border-radius: 20px; /* Rounded buttons */
+    background-color: var(--white, #fff);
+    color: var(--primary-color, #0C4178);
+    cursor: pointer;
+    font-family: 'Fredoka', sans-serif; /* Consistent font */
+    font-size: 0.9rem;
+    font-weight: 500;
+    transition: background-color 0.3s ease, color 0.3s ease, transform 0.2s ease;
+}
+
+.filter-button:hover {
+    background-color: var(--primary-color-light, #1E78BA); /* A lighter shade of primary for hover */
+    color: var(--white, #fff);
+    transform: translateY(-2px);
+}
+
+.filter-button.active {
+    background-color: var(--primary-color, #0C4178);
+    color: var(--white, #fff);
+    border-color: var(--primary-color, #0C4178);
+    box-shadow: 0 2px 5px rgba(0,0,0,0.2);
+}
+/* End Category Filter Styles */
 
 </style>
 
@@ -547,6 +587,19 @@ get_header();
     </div>
 </section>
 
+<?php
+$active_categories = get_terms('product_cat', array('hide_empty' => true));
+if (!empty($active_categories) && !is_wp_error($active_categories)) {
+    echo '<div class="category-filters-container">';
+    echo '<div class="category-filters">';
+    echo '<button class="filter-button active" data-category="all">All</button>';
+    foreach ($active_categories as $category) {
+        echo '<button class="filter-button" data-category="' . esc_attr($category->slug) . '">' . esc_html($category->name) . '</button>';
+    }
+    echo '</div>';
+    echo '</div>';
+}
+?>
 <section class="woocommerce-products-section">
   <div class="container">
     <?php


### PR DESCRIPTION
This commit introduces an AJAX-based product category filtering feature for your WooCommerce shop page.

Key changes include:
- Modified `page-boutique-ortoc.php` to include filter buttons and associated CSS.
- Created `ortoc-category-filter.js` to handle client-side click events, perform AJAX requests, and update the product display dynamically.
- Created `ortoc-ajax-functions.php` which contains the necessary PHP functions to be included in your theme's `functions.php`. This handles:
    - Enqueuing and localizing the JavaScript file.
    - Processing AJAX requests, querying products by category, and returning HTML.
- Added `README.md` with detailed step-by-step instructions for implementing these changes via cPanel.

The filter buttons allow you to select product categories and view corresponding products without a full page reload, enhancing user experience.